### PR TITLE
fix typo in code

### DIFF
--- a/jni/wqx/nc1020.cpp
+++ b/jni/wqx/nc1020.cpp
@@ -608,7 +608,7 @@ void Initialize(const char* path) {
 	for (size_t i=0; i<0x100; i++) {
 		rom_volume0[i] = rom_buff + (0x8000 * i);
 		rom_volume1[i] = rom_buff + (0x8000 * (0x100 + i));
-		rom_volume1[i] = rom_buff + (0x8000 * (0x200 + i));
+		rom_volume2[i] = rom_buff + (0x8000 * (0x200 + i));
 	}
 	for (size_t i=0; i<0x20; i++) {
 		nor_banks[i] = nor_buff + (0x8000 * i);

--- a/jni/wqx/nc1020.cpp
+++ b/jni/wqx/nc1020.cpp
@@ -536,7 +536,7 @@ inline void Store(uint16_t addr, uint8_t value) {
                 if (fp_type == 1) {
                     fp_bank_idx = bank_idx;
                     fp_bak1 = bank[0x4000];
-                    fp_bak1 = bank[0x4001];
+                    fp_bak2 = bank[0x4001];
                 }
                 fp_step = 3;
                 return;


### PR DESCRIPTION
I believe this is a typo since:

1. this line make the above line  a no-op

2. in the [js code](https://github.com/hackwaly/jswqx/blob/16979c1f37b1ceec35c32ca0d27c751c1d5f7162/src/wqx.js#L141C1-L148C7)  it's:

```
   Wqx.prototype.initRom = function (){
        this.rom = new Uint8Array(0x8000 * 768);
        for (var i=0; i<256; i++) {
            this.volume0array[i] = getByteArray(this.rom, 0x8000 * i, 0x8000);
            this.volume1array[i] = getByteArray(this.rom, 0x8000 * (i + 256), 0x8000);
            this.volume2array[i] = getByteArray(this.rom, 0x8000 * (i + 512), 0x8000);
        }
    };
```
